### PR TITLE
Roosting & ACC Reclassification Changes

### DIFF
--- a/app-configuration.json
+++ b/app-configuration.json
@@ -3,8 +3,8 @@
     "rooststart": 18,
     "roostend": 7,
     "create_plots": true,
-    "use_sunrise": false,
-    "sunrise_leeway": -30, 
-    "sunset_leeway": 30,
+    "use_sunrise": true,
+    "sunrise_leeway": -15, 
+    "sunset_leeway": 15,
     "altbound": 25
 }


### PR DESCRIPTION
- Introduced function for nested ACC unpacking & interpolation (interpolation step currently disabled)
- If necessary column (acc_dt) is available, ACC for each location is unpacked and transformed into three columns: var_acc_x, var_acc_y, var_acc_z
- Added column to define 'nighttime' locations as a binary variable based on sunrise/sunset-timestamp columns (if available) and the 'leeway' inputs
- Introduced nightroost reclassification identifying runs of 'roosting' points based on a before/after midnight location match: if a bird 'stays put' overnight, all stationary behaviour sandwiched between the first previous and first ensuing Travelling points becomes SRoosting